### PR TITLE
fix error Array to string conversion by implode meta keywords if its value is array

### DIFF
--- a/application/core/MY_Output.php
+++ b/application/core/MY_Output.php
@@ -191,7 +191,10 @@ class MY_Output extends CI_Output {
 
 			}
 
-			//$this->_meta["keywords"] = implode(" ,", $this->_meta["keywords"]);
+			if (is_array($this->_meta["keywords"]))
+			{
+				$this->_meta["keywords"] = implode(" ,", $this->_meta["keywords"]);
+			}
 
 			$data["output"] = $output;
 			$data["messages"] = $this->_messages;


### PR DESCRIPTION
I have just downloaded and test with clean install, and then access `example` controller, and I got this error:

```
A PHP Error was encountered  

Severity: Notice  

Message: Array to string conversion  

Filename: themes/default.php  

Line Number: 12  
Array" />  
```

To solve it, I do this commit just check first, if meta keywords' value is array then implode it.
